### PR TITLE
Update mock-core-configs "available soon" link

### DIFF
--- a/modules/ROOT/pages/buildroot.adoc
+++ b/modules/ROOT/pages/buildroot.adoc
@@ -59,7 +59,8 @@ fedpkg build [--scratch] --target eln [--srpm [SRPM]] [...]
 
 `mock` can also be used to perform builds locally.
 
-A supported `mock` configuration should be link:https://github.com/rpm-software-management/mock/pull/615[available soon] as part of the `mock-core-configs` package. This will enable the ELN environment to be used locally by running (for arch `x86_64`):
+A supported `mock` configuration is available in the `mock-core-configs` package version 33 or later.
+This enables the ELN environment to be used locally by running (for arch `x86_64`):
 
 ```
 mock -r fedora-eln-x86_64 ...
@@ -67,5 +68,5 @@ mock -r fedora-eln-x86_64 ...
 
 [NOTE]
 ====
-Until the official `mock` configuration becomes available, an unsupported configuration file can be downloaded link:{attachmentsdir}/fedora-eln-x86_64.cfg[here].
+If the official `mock` configuration is not yet available, an unsupported configuration file can be downloaded link:{attachmentsdir}/fedora-eln-x86_64.cfg[here].
 ====


### PR DESCRIPTION
Change the `mock-core-configs` "available soon" link to point to the Bodhi updates that add support for ELN.