### PR TITLE
Be clear about ways to build for ELN + preview.sh tweak

### DIFF
--- a/modules/ROOT/pages/buildroot.adoc
+++ b/modules/ROOT/pages/buildroot.adoc
@@ -51,7 +51,7 @@ There are no changes in compiler flags yet.
 [#building]
 == Building with the ELN buildroot
 
-Simply specify `eln` as the target when kicking off a build:
+Simply specify `eln` as the target when kicking off a `koji` build using `fedpkg`:
 
 ```
 fedpkg build [--scratch] --target eln [--srpm [SRPM]] [...]

--- a/modules/ROOT/pages/ftbfs.adoc
+++ b/modules/ROOT/pages/ftbfs.adoc
@@ -8,9 +8,7 @@ ELN build failures.
 
 For general information about ELN, visit the xref:index.adoc[overview].
 
-Note what’s different with the xref:buildroot.adoc[buildroot] for ELN,
-as well as details about xref:buildroot.adoc#building[how to build] using
-the ELN buildroot.
+Note what’s different with the xref:buildroot.adoc[buildroot] for ELN.
 
 The set of packages that currently need to build for ELN can be found at
 https://tiny.distro.builders/view\--view-eln.html.
@@ -20,6 +18,13 @@ https://tiny.distro.builders/view\--view-eln-and-buildroot.html.
 There is also an xref:status.adoc#_eln_builds[ELN Build Status page] showing
 which packages are currently failing to build for ELN, as well as those
 that have a discrepancy between Fedora Rawhide and ELN builds.
+
+
+== Debugging ELN build failures
+
+Check the details about xref:buildroot.adoc#building[how to build]
+with `koji` and `mock` using the ELN buildroot.
+
 
 == Fixing ELN build failures
 

--- a/preview.sh
+++ b/preview.sh
@@ -1,17 +1,19 @@
 #!/bin/sh
 
+: ${PORT:=8080}
+
 if [ "$(uname)" == "Darwin" ]; then
     # Running on macOS.
     # Let's assume that the user has the Docker CE installed
     # which doesn't require a root password.
-    echo "The preview will be available at http://localhost:8080/"
-    docker run --rm -v $(pwd):/antora:ro -v $(pwd)/nginx.conf:/etc/nginx/conf.d/default.conf:ro -p 8080:80 nginx
+    echo "The preview will be available at http://localhost:$PORT/"
+    docker run --rm -v $(pwd):/antora:ro -v $(pwd)/nginx.conf:/etc/nginx/conf.d/default.conf:ro -p $PORT:80 nginx
 
 elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
     # Running on Linux.
     # Fedora Workstation has python3 installed as a default, so using that
     echo ""
-    echo "The preview is available at http://localhost:8080"
+    echo "The preview is available at http://localhost:$PORT"
     echo ""
 
     if [[ "$*" == *--refresh* ]]; then
@@ -27,13 +29,13 @@ elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
         trap killgroup SIGINT
 
         # Run the Python's webserver.
-        python3 -m http.server 8080 --directory ./public &
+        python3 -m http.server $PORT --directory ./public &
 
         while inotifywait -r ./modules -e create -e moved_to -e modify; do
              echo "Documentation source changed, rebuilding ..."
             ./build.sh
         done
     else
-        python3 -m http.server 8080 --directory ./public
+        python3 -m http.server $PORT --directory ./public
     fi
 fi


### PR DESCRIPTION
Revised ftbfs and buildroot pages to be more clear about ways to build for ELN (based on feedback).

Minor adjustments to preview.sh to make it easily to select a different port in case of a local clash.
