### PR TITLE
Include link to matrix room

### DIFF
--- a/modules/ROOT/pages/sig.adoc
+++ b/modules/ROOT/pages/sig.adoc
@@ -32,7 +32,11 @@ The official SIG membership list is maintained as part of our Github Organizatio
 
 * Mailing list: Add *[ELN]* to the subject of an email to the https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/[devel@ mailing list]
 
+* Matrix Room: https://matrix.to/#/#eln:fedoraproject.org[#eln:fedoraproject.org]
 * IRC: https://web.libera.chat/?channels=#fedora-eln[#fedora-eln on Libera]
+
+* The IRC channel is bridged to the Matrix room, so logging in to either one
+* will suffice.
 
 === Issue tracker
 


### PR DESCRIPTION
- List the matrix room first to reflect fedora's matrix first approach.
- Also mention that the irc channel is bridged to the matrix room.