### PR TITLE
Add link to SIGs calendar

### DIFF
--- a/modules/ROOT/pages/sig.adoc
+++ b/modules/ROOT/pages/sig.adoc
@@ -44,7 +44,7 @@ The official SIG membership list is maintained as part of our Github Organizatio
 
 === Meetings
 
-Meetings of the ELN Special Interest Group are held on Fridays at noon, US Eastern Time.
+Meetings of the ELN Special Interest Group are held on Fridays at noon, US Eastern Time. It is listed on the https://calendar.fedoraproject.org/SIGs/[SIGs calendar].
 
 The meeting agenda will generally be prepared in advance by opening tickets on the https://github.com/fedora-eln/eln/issues[issue tracker] and tagging them with the `meeting` label.
 


### PR DESCRIPTION
Since both @tdawson and I had problems finding ELN's calendar listing, it probably should get added to our docs