### PR TITLE
Clarify ACL needed for requesting branch

### DIFF
--- a/modules/ROOT/pages/eln-branch.adoc
+++ b/modules/ROOT/pages/eln-branch.adoc
@@ -21,11 +21,14 @@ maintaining the eln branch.
 === You ARE the Fedora maintainer
 
 If you are a Fedora maintainer of the package needing a branch, then
-the next step if fairly simple.
+the next step is fairly simple.
 
 ....
 fedpkg request-branch eln --no-auto-module --repo <package>
 ....
+
+If there is an error about expired or invalid token, make sure to set up a token 
+with ACL "Create a new ticket".
 
 === You ARE NOT the Fedora maintainer
 


### PR DESCRIPTION
Somewhat unintuitively, you need the "Create a ticket" ACL for the `fedpkg request-branch` command, because it just created this ticket: https://pagure.io/releng/fedora-scm-requests/issue/77929 I never needed to interact with the Pagure API before, so I didn't have any API key before this. I wanted minimal permissions, so I chose "Modify a project" because that sounded reasonable and that's why my previous attempts for requesting branch failed. I was also trying out API keys from the dist-git Pagure instance and project settings... Then I just created the API key with all ACLs and it finally worked - but I wanted to document this as I wasn't able to find any help by searching the internet.